### PR TITLE
complete federation ranking/voting flow end-to-end: Add federation ra…

### DIFF
--- a/app/Console/Commands/CalculateAllRankingAverages.php
+++ b/app/Console/Commands/CalculateAllRankingAverages.php
@@ -8,6 +8,7 @@ use App\Models\RankingTagTeamAverage;
 use App\Models\RankingWrestlerAverage;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use App\Models\RankingFederationAverage;
 
 class CalculateAllRankingAverages extends Command
 {
@@ -21,6 +22,7 @@ class CalculateAllRankingAverages extends Command
         DB::transaction(function () {
             RankingWrestlerAverage::query()->delete();
             RankingTagTeamAverage::query()->delete();
+            RankingFederationAverage::query()->delete();
         });
 
         // Wrestler rankings
@@ -89,6 +91,40 @@ class CalculateAllRankingAverages extends Command
             RankingTagTeamAverage::insert($payload);
 
             $this->info("Tag team ranking {$ranking->id}: inserted " . count($payload) . " rows");
+        }
+
+         // Federation rankings
+        $federationRankings = Ranking::where('type', RankingType::Federation->value)->get();
+
+        foreach ($federationRankings as $ranking) {
+            $results = DB::table('votes_federation')
+                ->select(
+                    'federation_id',
+                    DB::raw('COUNT(*) as votes_count'),
+                    DB::raw('SUM(vote)::numeric(10,2) as votes_sum'),
+                    DB::raw('ROUND(AVG(vote)::numeric, 2) as average_vote')
+                )
+                ->where('ranking_id', $ranking->id)
+                ->groupBy('federation_id')
+                ->get();
+
+            if ($results->isEmpty()) {
+                continue;
+            }
+
+            $payload = $results->map(fn ($row) => [
+                'ranking_id'   => $ranking->id,
+                'federation_id'  => $row->federation_id,
+                'votes_count'  => (int) $row->votes_count,
+                'votes_sum'    => (float) $row->votes_sum,
+                'average_vote' => round((float) $row->average_vote, 2),
+                'created_at'   => now(),
+                'updated_at'   => now(),
+            ])->all();
+
+            RankingFederationAverage::insert($payload);
+
+            $this->info("Federation ranking {$ranking->id}: inserted " . count($payload) . " rows");
         }
 
         $this->info('Averages rebuild completed.');

--- a/app/Enums/RankingType.php
+++ b/app/Enums/RankingType.php
@@ -6,6 +6,7 @@ enum RankingType: string
 {
     case Wrestler = 'wrestler';
     case TagTeam = 'tag team';
+    case Federation = 'federation';
 
     public static function values(): array
     {

--- a/app/Events/VoteAdded.php
+++ b/app/Events/VoteAdded.php
@@ -2,8 +2,6 @@
 
 namespace App\Events;
 
-use App\Models\VoteTagTeam;
-use App\Models\VoteWrestler;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;

--- a/app/Http/Controllers/Admin/RankingManagementController.php
+++ b/app/Http/Controllers/Admin/RankingManagementController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\RankingType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreRankingRequest;
 use App\Http\Requests\UpdateRankingRequest;
@@ -18,13 +19,21 @@ class RankingManagementController extends Controller
         $rankings = Ranking::with(['category', 'federation', 'categories', 'federations', 'rankingCountries'])->get();
         $categories = Category::all();
         $federations = Federation::all();
+        $federationRankingExists = Ranking::where('type', RankingType::Federation->value)->exists();
 
-        return view('admin.ranking', compact('rankings', 'categories', 'federations'));
+        return view('admin.ranking', compact('rankings', 'categories', 'federations', 'federationRankingExists'));
     }
 
     public function store(StoreRankingRequest $request)
     {
         $rankingAttributes = $request->validated();
+
+        if (($rankingAttributes['type'] ?? null) === RankingType::Federation->value
+            && Ranking::where('type', RankingType::Federation->value)->exists()) {
+            return back()
+                ->withInput()
+                ->with('error', 'È consentito un solo ranking federazioni.');
+        }
 
         $categoryIds = $this->normalizeIds($rankingAttributes['category_ids'] ?? [], $rankingAttributes['category_id'] ?? null);
         $federationIds = $this->normalizeIds($rankingAttributes['federation_ids'] ?? [], $rankingAttributes['federation_id'] ?? null);
@@ -60,6 +69,26 @@ class RankingManagementController extends Controller
         return redirect()->route('admin.ranking')->with('success', 'Ranking aggiunto con successo.');
     }
 
+    public function createFederationRanking()
+    {
+        $ranking = Ranking::firstOrCreate(
+            ['type' => RankingType::Federation->value],
+            [
+                'name' => 'Ranking Federazioni',
+                'description' => 'Classifica generale delle federazioni basata sui voti degli utenti.',
+                'status' => true,
+                'filter_type' => 'none',
+                'includes_inactive' => true,
+            ]
+        );
+
+        if (!$ranking->wasRecentlyCreated) {
+            return redirect()->route('admin.ranking')->with('error', 'Il ranking federazioni esiste già.');
+        }
+
+        return redirect()->route('admin.ranking')->with('success', 'Ranking federazioni creato con successo.');
+    }
+
     public function edit($id)
     {
         $ranking = Ranking::with(['categories', 'federations', 'rankingCountries'])->findOrFail($id);
@@ -75,17 +104,36 @@ class RankingManagementController extends Controller
         $ranking = Ranking::with(['categories', 'federations', 'rankingCountries'])->findOrFail($id);
         $validatedData = $request->validated();
 
-        $categoryIds = $this->normalizeIds($validatedData['category_ids'] ?? [], $validatedData['category_id'] ?? null);
-        $federationIds = $this->normalizeIds($validatedData['federation_ids'] ?? [], $validatedData['federation_id'] ?? null);
-        $countries = $this->normalizeCountries($validatedData['countries_text'] ?? null, $validatedData['country'] ?? null);
+        $isFederationRanking = $ranking->type === RankingType::Federation->value;
+
+        $categoryIds = $isFederationRanking
+            ? []
+            : $this->normalizeIds($validatedData['category_ids'] ?? [], $validatedData['category_id'] ?? null);
+        $federationIds = $isFederationRanking
+            ? []
+            : $this->normalizeIds($validatedData['federation_ids'] ?? [], $validatedData['federation_id'] ?? null);
+        $countries = $isFederationRanking
+            ? []
+            : $this->normalizeCountries($validatedData['countries_text'] ?? null, $validatedData['country'] ?? null);
 
         $validatedData['category_id'] = $categoryIds[0] ?? null;
         $validatedData['federation_id'] = $federationIds[0] ?? null;
         $validatedData['country'] = empty($countries) ? null : implode(', ', $countries);
-        $validatedData['filter_type'] = $this->resolveFilterType($categoryIds, $federationIds, $countries);
+        $validatedData['filter_type'] = $isFederationRanking
+            ? 'none'
+            : $this->resolveFilterType($categoryIds, $federationIds, $countries);
 
         try {
-            DB::transaction(function () use ($ranking, $validatedData, $categoryIds, $federationIds, $countries): void {
+            DB::transaction(function () use ($ranking, $validatedData, $categoryIds, $federationIds, $countries, $isFederationRanking): void {
+                if ($isFederationRanking) {
+                    $ranking->update([
+                        'category_id' => null,
+                        'federation_id' => null,
+                        'country' => null,
+                        'filter_type' => 'none',
+                    ]);
+                }    
+            
                 $ranking->update($validatedData);
                 $ranking->categories()->sync($categoryIds);
                 $ranking->federations()->sync($federationIds);

--- a/app/Http/Controllers/Auth/SessionController.php
+++ b/app/Http/Controllers/Auth/SessionController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 
@@ -23,13 +22,13 @@ class SessionController extends Controller
 
         if (! Auth::attempt($attributes)) {
             throw ValidationException::withMessages([
-                'email' => 'Sorry, those credentials do not match.'
+                'email' => 'Email o password errati, riprova grazie.'
             ]);
         }
 
         request()->session()->regenerate();
 
-        return redirect('/');
+        return redirect('/')->with('success', 'Login effettuato con successo.');
     }
 
     public function destroy()

--- a/app/Http/Controllers/FederationController.php
+++ b/app/Http/Controllers/FederationController.php
@@ -5,9 +5,15 @@ namespace App\Http\Controllers;
 use App\Models\TagTeam;
 use App\Models\Wrestler;
 use App\Models\Federation;
+use App\Services\CandidateService;
+use Illuminate\Http\Request;
 
 class FederationController extends Controller
 {
+    public function __construct(private readonly CandidateService $candidateService)
+    {
+    }
+
     public function index()
     {
         $federations = Federation::all();
@@ -15,6 +21,23 @@ class FederationController extends Controller
             return redirect()->route('home')->with('error', 'Nessuna federazione disponibile.');
         }
         return view('federations.index', compact('federations'));
+    }
+
+    public function candidates(Request $request)
+    {
+        $rankingId = $request->query('ranking_id');
+
+        $ranking = $this->candidateService->resolveRanking($rankingId);
+        if (!$ranking) {
+            return redirect()->back()->with('error', 'Ranking non disponibile per questa votazione.');
+        }
+
+        $federations = Federation::orderBy('name')->get();
+
+        return view('votes.federation.candidates', [
+            'federations' => $federations,
+            'ranking' => $ranking,
+        ]);
     }
 
     public function show($id)

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -6,6 +6,7 @@ use App\Enums\RankingType;
 use App\Models\Ranking;
 use App\Models\RankingTagTeamAverage;
 use App\Models\RankingWrestlerAverage;
+use App\Models\RankingFederationAverage;
 
 class RankingController extends Controller
 {
@@ -46,6 +47,16 @@ class RankingController extends Controller
     
         return view('votes.tag_team.ranking-list', ['rankings' => $rankings]);
     }
+
+    public function ranking_list_federation()
+    {
+        $rankings = Ranking::where('status', true)
+            ->get(['id', 'name', 'description', 'type', 'filter_type', 'category_id', 'federation_id', 'country', 'includes_inactive'])
+            ->filter(fn (Ranking $ranking) => $this->isRankingType($ranking, RankingType::Federation))
+            ->values();
+
+        return view('votes.federation.ranking-list', ['rankings' => $rankings]);
+    }
     
     public function show($rankingId)
     {
@@ -53,7 +64,7 @@ class RankingController extends Controller
     
         $participants = collect();
 
-        if ($ranking->type === 'wrestler') {
+        if ($ranking->type === RankingType::Wrestler->value) {
             $participants = RankingWrestlerAverage::with(RankingType::Wrestler->value)
                 ->where('ranking_id', $rankingId)
                 ->orderByDesc('average_vote')
@@ -78,6 +89,18 @@ class RankingController extends Controller
                         'votes_count'   => $rta->votes_count,
                     ];
                 });
+        } elseif ($ranking->type === RankingType::Federation->value) {
+            $participants = RankingFederationAverage::with('federation')
+                ->where('ranking_id', $rankingId)
+                ->orderByDesc('average_vote')
+                ->get()
+                ->map(function ($rfa) {
+                    return (object) [
+                        'participant'   => $rfa->federation,
+                        'average_vote'  => $rfa->average_vote,
+                        'votes_count'   => $rfa->votes_count,
+                    ];
+                });
         }
 
         return view('rankings.show', compact('ranking', 'participants'));
@@ -94,6 +117,6 @@ class RankingController extends Controller
             return '';
         }
 
-         return str_replace(['_', '-', ' '], '', strtolower(trim($value)));
+        return str_replace(['_', '-', ' '], '', strtolower(trim($value)));
     }
 }

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Federation;
+use App\Models\Ranking;
+use App\Models\TagTeam;
+use App\Models\Wrestler;
+use Illuminate\Http\Request;
+
+class SearchController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = trim((string) $request->query('query', ''));
+
+        if ($query === '') {
+            return view('search.index', [
+                'query' => $query,
+                'wrestlers' => collect(),
+                'tagTeams' => collect(),
+                'federations' => collect(),
+                'rankings' => collect(),
+            ]);
+        }
+
+        $wrestlers = Wrestler::query()
+            ->where('name', 'like', "%{$query}%")
+            ->orderBy('name')
+            ->limit(15)
+            ->get();
+
+        $tagTeams = TagTeam::query()
+            ->where('name', 'like', "%{$query}%")
+            ->orderBy('name')
+            ->limit(15)
+            ->get();
+
+        $federations = Federation::query()
+            ->where('name', 'like', "%{$query}%")
+            ->orderBy('name')
+            ->limit(15)
+            ->get();
+
+        $rankings = Ranking::query()
+            ->where('name', 'like', "%{$query}%")
+            ->orderBy('name')
+            ->limit(15)
+            ->get();
+
+        return view('search.index', compact('query', 'wrestlers', 'tagTeams', 'federations', 'rankings'));
+    }
+}

--- a/app/Http/Controllers/VoteController.php
+++ b/app/Http/Controllers/VoteController.php
@@ -3,13 +3,16 @@
 namespace App\Http\Controllers;
 
 use App\Events\VoteAdded;
+use App\Http\Requests\StoreFederationVoteRequest;
 use App\Http\Requests\StoreTagTeamVoteRequest;
 use App\Http\Requests\StoreWrestlerVoteRequest;
+use App\Models\Federation;
 use App\Models\Ranking;
 use App\Models\TagTeam;
-use App\Models\Wrestler;
+use App\Models\VoteFederation;
 use App\Models\VoteTagTeam;
 use App\Models\VoteWrestler;
+use App\Models\Wrestler;
 use App\Services\VoteService;
 use Illuminate\Support\Facades\Auth;
 
@@ -55,6 +58,21 @@ class VoteController extends Controller
         ]);
     }
 
+    public function showFederationVoteForm(Federation $federation, Ranking $ranking)
+    {
+        $existingVote = VoteFederation::where('user_id', Auth::id())
+            ->where('federation_id', $federation->id)
+            ->where('ranking_id', $ranking->id)
+            ->value('vote');
+
+        return view('votes.federation.vote', [
+            'federation' => $federation,
+            'ranking' => $ranking,
+            'existingVote' => $existingVote,
+            'voteOptions' => $this->generateVoteOptions(),
+        ]);
+    }
+
     private function generateVoteOptions()
     {
         $options = [];
@@ -93,6 +111,22 @@ class VoteController extends Controller
 
         event(new VoteAdded($vote));
     
+        return redirect()->route('user.profile')->with('success', 'Il tuo voto è stato salvato con successo.');
+    }
+
+    public function federationVoteStore(StoreFederationVoteRequest $request)
+    {
+        $validated = $request->validated();
+        $result = $this->voteService->createFederationVote((int) Auth::id(), $validated);
+
+        if (isset($result['error'])) {
+            return redirect()->back()->with('error', $result['error']);
+        }
+
+        $vote = $result['vote'];
+
+        event(new VoteAdded($vote));
+
         return redirect()->route('user.profile')->with('success', 'Il tuo voto è stato salvato con successo.');
     }
 }

--- a/app/Http/Requests/StoreFederationVoteRequest.php
+++ b/app/Http/Requests/StoreFederationVoteRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreFederationVoteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'federation_id' => ['required', 'exists:federations,id'],
+            'ranking_id' => ['required', 'exists:rankings,id'],
+            'vote' => ['required', 'numeric', 'min:0', 'max:10'],
+        ];
+    }
+}

--- a/app/Jobs/UpdateFederationAverage.php
+++ b/app/Jobs/UpdateFederationAverage.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\RankingFederationAverage;
+use App\Models\VoteFederation;
+use App\Services\RankingAverageService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateFederationAverage implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $rankingId;
+    public int $federationId;
+
+    public function __construct(int $rankingId, int $federationId)
+    {
+        $this->rankingId = $rankingId;
+        $this->federationId = $federationId;
+    }
+
+    public function handle(RankingAverageService $rankingAverageService): void
+    {
+        $rankingAverageService->updateAverage(
+            VoteFederation::class,
+            RankingFederationAverage::class,
+            'federation_id',
+            $this->rankingId,
+            $this->federationId,
+        );
+    }
+}

--- a/app/Listeners/UpdateRankingAverage.php
+++ b/app/Listeners/UpdateRankingAverage.php
@@ -8,6 +8,8 @@ use App\Jobs\UpdateTagTeamAverage;
 use App\Jobs\UpdateWrestlerAverage;
 use App\Models\VoteTagTeam;
 use App\Models\VoteWrestler;
+use App\Jobs\UpdateFederationAverage;
+use App\Models\VoteFederation;
 
 class UpdateRankingAverage
 {
@@ -22,6 +24,10 @@ class UpdateRankingAverage
 
         if ($vote instanceof VoteTagTeam) {
             UpdateTagTeamAverage::dispatch($vote->ranking_id, $vote->tag_team_id);
+        }
+
+        if ($vote instanceof VoteFederation) {
+            UpdateFederationAverage::dispatch($vote->ranking_id, $vote->federation_id);
         }
     }
 }

--- a/app/Models/Ranking.php
+++ b/app/Models/Ranking.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Models\RankingCountry;
+use App\Models\RankingFederationAverage;
+use App\Models\VoteFederation;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -74,5 +76,15 @@ class Ranking extends Model
     public function tagTeamAverages()
     {
         return $this->hasMany(RankingTagTeamAverage::class);
+    }
+
+    public function votesFederation()
+    {
+        return $this->hasMany(VoteFederation::class);
+    }
+
+    public function federationAverages()
+    {
+        return $this->hasMany(RankingFederationAverage::class);
     }
 }

--- a/app/Models/RankingFederationAverage.php
+++ b/app/Models/RankingFederationAverage.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class RankingFederationAverage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ranking_id',
+        'federation_id',
+        'votes_count',
+        'votes_sum',
+        'average_vote',
+    ];
+
+    public function ranking()
+    {
+        return $this->belongsTo(Ranking::class);
+    }
+
+    public function federation()
+    {
+        return $this->belongsTo(Federation::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,10 +3,11 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Models\VoteFederation;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Authenticatable
 {
@@ -59,4 +60,8 @@ class User extends Authenticatable
         return $this->hasMany(VoteTagTeam::class);
     }
 
+    public function votesFederation(): HasMany
+    {
+        return $this->hasMany(VoteFederation::class);
+    }
 }

--- a/app/Models/VoteFederation.php
+++ b/app/Models/VoteFederation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class VoteFederation extends AbstractVote
+{
+    use HasFactory;
+
+    protected $table = 'votes_federation';
+
+    protected $fillable = [
+        'user_id',
+        'federation_id',
+        'ranking_id',
+        'vote',
+    ];
+
+    public function federation(): BelongsTo
+    {
+        return $this->belongsTo(Federation::class);
+    }
+
+    public function participant(): BelongsTo
+    {
+        return $this->federation();
+    }
+}

--- a/app/Services/VoteService.php
+++ b/app/Services/VoteService.php
@@ -6,6 +6,7 @@ use App\Enums\RankingType;
 use App\Models\Ranking;
 use App\Models\VoteTagTeam;
 use App\Models\VoteWrestler;
+use App\Models\VoteFederation;
 
 class VoteService
 {
@@ -43,6 +44,28 @@ class VoteService
             [
                 'user_id' => $userId,
                 'tag_team_id' => $validated['tag_team_id'],
+                'ranking_id' => $validated['ranking_id'],
+            ],
+            [
+                'vote' => $validated['vote'],
+            ]
+        );
+
+        return ['vote' => $vote];
+    }
+
+    public function createFederationVote(int $userId, array $validated): array
+    {
+        $ranking = Ranking::find($validated['ranking_id']);
+
+        if (!$ranking || $ranking->type !== RankingType::Federation->value) {
+            return ['error' => 'Questo ranking non accetta votazioni per federazioni.'];
+        }
+
+        $vote = VoteFederation::updateOrCreate(
+            [
+                'user_id' => $userId,
+                'federation_id' => $validated['federation_id'],
                 'ranking_id' => $validated['ranking_id'],
             ],
             [

--- a/database/factories/RankingFactory.php
+++ b/database/factories/RankingFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Enums\RankingType;
 use App\Models\Ranking;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Category;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Ranking>
@@ -24,7 +25,7 @@ class RankingFactory extends Factory
             'description' => $this->faker->paragraph,
             'type' => $this->faker->randomElement(RankingType::values()), // add later 'federation' or other entities
             'status' => $this->faker->boolean,
-            'category_id' => $this->faker->numberBetween(1, 10),
+            'category_id' => Category::factory(),
             'includes_inactive' => $this->faker->boolean,
         ];
     }

--- a/database/migrations/2026_04_25_113943_create_votes_federation_table.php
+++ b/database/migrations/2026_04_25_113943_create_votes_federation_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('votes_federation', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('federation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('ranking_id')->constrained()->cascadeOnDelete();
+            $table->decimal('vote', 3, 1);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'federation_id', 'ranking_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('votes_federation');
+    }
+};

--- a/database/migrations/2026_04_25_114035_create_ranking_federation_averages_table.php
+++ b/database/migrations/2026_04_25_114035_create_ranking_federation_averages_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ranking_federation_averages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ranking_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('federation_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('votes_count')->default(0);
+            $table->decimal('votes_sum', 10, 2)->default(0);
+            $table->decimal('average_vote', 4, 2)->default(0);
+            $table->timestamps();
+
+            $table->unique(['ranking_id', 'federation_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ranking_federation_averages');
+    }
+};

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -1,0 +1,39 @@
+<x-layout>
+    <x-second-title>Il progetto / About this project</x-second-title>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h2 class="h4 mb-3">Italiano</h2>
+            <p>
+                Questo sito nasce per la community di Indyvidui Italiani. L'obiettivo è offrire una piattaforma
+                semplice dove gli utenti registrati possono esplorare candidature, votare e consultare classifiche
+                aggiornate in base ai voti della community.
+            </p>
+            <p>
+                Le sezioni principali del sito sono:
+            </p>
+            <ul>
+                <li><strong>Votazioni:</strong> per esprimere le proprie preferenze.</li>
+                <li><strong>Classifiche:</strong> per vedere i risultati aggiornati.</li>
+                <li><strong>Federazioni e candidati:</strong> per approfondire i partecipanti.</li>
+            </ul>
+
+            <hr>
+
+            <h2 class="h4 mb-3">English</h2>
+            <p>
+                This website was created for the Indyvidui Italiani community. Its goal is to provide a simple
+                platform where registered users can browse candidates, vote, and view rankings updated according
+                to community votes.
+            </p>
+            <p>
+                The main sections are:
+            </p>
+            <ul>
+                <li><strong>Voting:</strong> to submit your preferences.</li>
+                <li><strong>Rankings:</strong> to check updated results.</li>
+                <li><strong>Federations and candidates:</strong> to learn more about participants.</li>
+            </ul>
+        </div>
+    </div>
+</x-layout>

--- a/resources/views/admin/edit-ranking.blade.php
+++ b/resources/views/admin/edit-ranking.blade.php
@@ -12,6 +12,8 @@
         if (empty($selectedFederationIds) && $ranking->federation_id) {
             $selectedFederationIds = [$ranking->federation_id];
         }
+
+        $isFederationRanking = $ranking->type === 'federation';
     @endphp
 
     <h2 class="text-center">Modifica Ranking: {{ $ranking->name }}</h2>
@@ -47,6 +49,7 @@
                 <textarea rows="3" name="description" id="description" class="form-control">{{ old('description', $ranking->description) }}</textarea>
             </div>
 
+            @unless($isFederationRanking)
             <div class="form-group mb-3">
                 <label for="category_ids">Categorie (facoltative, selezione multipla):</label>
                 <select name="category_ids[]" id="category_ids" class="form-select" multiple>
@@ -69,7 +72,8 @@
                 <label for="countries_text">Nazionalità (una o più, separate da virgola):</label>
                 <input type="text" name="countries_text" id="countries_text" value="{{ old('countries_text', $ranking->country) }}" class="form-control" placeholder="Italy, Japan, Mexico">
             </div>
-
+            @endunless
+            
             <div class="form-group mb-3">
                 <label for="status">Status del Ranking:</label>
                 <select name="status" class="form-select">

--- a/resources/views/admin/ranking.blade.php
+++ b/resources/views/admin/ranking.blade.php
@@ -57,6 +57,17 @@
     </div>
     <div class="row">
         <h3>Aggiungi Ranking</h3>
+        <div class="mb-3">
+            <form action="{{ route('admin.ranking.federation.create') }}" method="post" class="d-inline-block">
+                @csrf
+                <button type="submit" class="btn btn-outline-primary" {{ ($federationRankingExists ?? false) ? 'disabled' : '' }}>
+                    Crea ranking federazioni
+                </button>
+            </form>
+            @if($federationRankingExists ?? false)
+                <small class="d-block text-muted mt-2">Il ranking federazioni esiste già.</small>
+            @endif
+        </div>
         <form action="{{ route('admin.ranking.store') }}" method="post" class="form-inline d-inline-block">
             @csrf
             <div class="form-group mb-3 d-block">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,5 +1,16 @@
 <x-layout>
     <x-second-title>Login</x-second-title>
+    @error('email')
+        <div class="alert alert-danger">
+            {{ $message }}
+        </div>
+    @enderror
+
+    @if(session('success'))
+        <div class="alert alert-success">
+            {{ session('success') }}
+        </div>
+    @endif
     <form action="/login" method="post">
         @csrf
         @method('')

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -57,10 +57,16 @@
                         </ul>
                     </li>
                 </ul>
-                <form action="" method="get">
-                    <input type="hidden" name="page" value="search">
-                    <input type="text" name="query" placeholder="Cerca nel sito..." required>
-                    <button type="submit">Cerca</button>
+                <form action="{{ route('search.index') }}" method="get" class="d-flex" role="search">
+                    <input
+                        type="text"
+                        name="query"
+                        class="form-control me-2"
+                        placeholder="Cerca nel sito..."
+                        value="{{ request('query') }}"
+                        aria-label="Cerca nel sito"
+                    >
+                    <button type="submit" class="btn btn-dark">Cerca</button>
                 </form>
                 </div>
             </div>

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -23,6 +23,9 @@
                         <a class="nav-link active" aria-current="page" href="/">Home</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ route('about') }}">Il Progetto/About the project</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ route('vote.lists.index') }}">Votazioni</a>
                     </li>
                     <li class="nav-item">

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -13,7 +13,6 @@
             {{ session('success') }}
         </div>
     @endif
-
     <x-main-card 
         title="Votazioni" 
         text="Questa sezione permetterà agli utenti di votare per i loro show o incontri preferiti." 

--- a/resources/views/rankings/index.blade.php
+++ b/resources/views/rankings/index.blade.php
@@ -38,4 +38,23 @@
             <li>Nessuna classifica per tag team disponibile.</li>
         @endforelse
     </ul>
+
+    <!-- Classifiche per Federazioni -->
+    <h4>Federazioni</h4>
+    <ul>
+        @forelse($rankings->where('type', 'federation') as $ranking)
+            <li>
+                <a href="{{ route('rankings.show', $ranking->id) }}">
+                    {{ $ranking->name }} - 
+                    @if($ranking->status)
+                        <span class="mx-2 badge badge-success bg-success">Attiva</span>
+                    @else
+                        <span class="mx-2 badge badge-danger bg-secondary">Inattiva</span>
+                    @endif
+                </a>
+            </li>
+        @empty
+            <li>Nessuna classifica per federazioni disponibile.</li>
+        @endforelse
+    </ul>
 </x-layout>

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -1,0 +1,47 @@
+<x-layout>
+    <x-second-title>Risultati ricerca</x-second-title>
+
+    @if($query === '')
+        <p>Inserisci un testo nella barra di ricerca per trovare wrestler, tag team, federazioni o classifiche.</p>
+    @else
+        <p>
+            Risultati per: <strong>{{ $query }}</strong>
+        </p>
+
+        <h4>Wrestler</h4>
+        <ul>
+            @forelse($wrestlers as $wrestler)
+                <li><a href="{{ route('wrestlers.show', $wrestler) }}">{{ $wrestler->name }}</a></li>
+            @empty
+                <li>Nessun wrestler trovato.</li>
+            @endforelse
+        </ul>
+
+        <h4>Tag Team</h4>
+        <ul>
+            @forelse($tagTeams as $tagTeam)
+                <li><a href="{{ route('tag-teams.show', $tagTeam) }}">{{ $tagTeam->name }}</a></li>
+            @empty
+                <li>Nessun tag team trovato.</li>
+            @endforelse
+        </ul>
+
+        <h4>Federazioni</h4>
+        <ul>
+            @forelse($federations as $federation)
+                <li><a href="{{ route('federations.show', $federation->id) }}">{{ $federation->name }}</a></li>
+            @empty
+                <li>Nessuna federazione trovata.</li>
+            @endforelse
+        </ul>
+
+        <h4>Classifiche</h4>
+        <ul>
+            @forelse($rankings as $ranking)
+                <li><a href="{{ route('rankings.show', $ranking->id) }}">{{ $ranking->name }}</a></li>
+            @empty
+                <li>Nessuna classifica trovata.</li>
+            @endforelse
+        </ul>
+    @endif
+</x-layout>

--- a/resources/views/votes/federation/candidates.blade.php
+++ b/resources/views/votes/federation/candidates.blade.php
@@ -1,0 +1,19 @@
+<x-layout>
+    <x-second-title>Lista delle Federazioni - {{ $ranking->name }}</x-second-title>
+    <p>Scegli la federazione da votare</p>
+
+    @if(session('error'))
+        <div class="alert alert-danger">
+            {{ session('error') }}
+        </div>
+    @endif
+
+    <ul class="list-group">
+        @foreach($federations as $federation)
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <a href="{{ route('federations.show', $federation->id) }}">{{ $federation->name }}</a>
+                <a class="btn btn-primary" href="{{ route('vote.federation.form', ['federation' => $federation->id, 'ranking' => $ranking->id]) }}">Vota</a>
+            </li>
+        @endforeach
+    </ul>
+</x-layout>

--- a/resources/views/votes/federation/ranking-list.blade.php
+++ b/resources/views/votes/federation/ranking-list.blade.php
@@ -1,0 +1,15 @@
+<x-layout>
+    @if($rankings->isEmpty())
+        <div class="alert alert-info">
+            Non ci sono federation ranking disponibili.
+        </div>
+    @else
+        @foreach ($rankings as $ranking)
+            <x-sub-card
+                title="{{ $ranking->name }}"
+                text="{{ $ranking->description }}"
+                href="{{ route('federations.candidates', ['ranking_id' => $ranking->id]) }}"
+            />
+        @endforeach
+    @endif
+</x-layout>

--- a/resources/views/votes/federation/vote.blade.php
+++ b/resources/views/votes/federation/vote.blade.php
@@ -1,0 +1,40 @@
+<x-layout>
+    <x-second-title>Vota per {{ $federation->name }} - nel ranking: {{ $ranking->name }}</x-second-title>
+
+    @if(session('error'))
+        <div class="alert alert-danger">
+            {{ session('error') }}
+        </div>
+    @endif
+
+    @if(session('success'))
+        <div class="alert alert-success">
+            {{ session('success') }}
+        </div>
+    @endif
+
+    <div><strong>Federazione:</strong> {{ $federation->name }}</div>
+
+    <form action="{{ route('vote.federation.store') }}" method="POST">
+        @csrf
+        <input type="hidden" name="federation_id" value="{{ $federation->id }}">
+        <input type="hidden" name="ranking_id" value="{{ $ranking->id }}">
+
+        <div class="form-group">
+            <label for="vote">Seleziona il tuo voto:</label>
+            @if($existingVote !== null)
+                <p><strong>Voto attuale:</strong> {{ $existingVote }}</p>
+            @endif
+            <div>
+                @foreach($voteOptions as $option)
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" name="vote" id="vote-{{ $option }}" value="{{ $option }}" {{ (float) $existingVote === (float) $option ? 'checked' : '' }} required>
+                        <label class="form-check-label" for="vote-{{ $option }}">{{ $option }}</label>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+
+        <button type="submit" class="btn btn-primary mt-3">{{ $existingVote !== null ? 'Aggiorna voto' : 'Vota' }}</button>
+    </form>
+</x-layout>

--- a/resources/views/votes/index.blade.php
+++ b/resources/views/votes/index.blade.php
@@ -14,7 +14,7 @@
     <x-main-card 
         title="Federazioni" 
         text="Tutte le votazioni relative alle Federazioni" 
-        href="/" 
+        href="/ranking-list-federation" 
         linkLabel="Federazioni" 
     />
 </x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,10 @@ Route::get('/', function () {
     return view('index');
 })->name('home');
 
+Route::get('/about-project', function () {
+    return view('about');
+})->name('about');
+
 // Auth Routes
 Route::middleware('guest')->group(function(){
     Route::get('/register', [RegisteredUserController::class, 'create'])->name('register');

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,7 @@ Route::middleware(['auth.custom', 'admin'])->group(function () {
     Route::put('/admin/ranking/{id}', [RankingManagementController::class, 'update'])->name('admin.ranking.update');
     Route::post('/admin/ranking', [RankingManagementController::class, 'store'])->name('admin.ranking.store');
     Route::delete('/admin/ranking/{id}/delete', [RankingManagementController::class, 'destroy'])->name('admin.ranking.delete');
+        Route::post('/admin/ranking/create-federation', [RankingManagementController::class, 'createFederationRanking'])->name('admin.ranking.federation.create');
 });
 
 // Ranking Routes
@@ -102,6 +103,7 @@ Route::get('/rankings/show/{ranking}', [RankingController::class, 'show'])->name
 
 Route::get('/ranking-list-wrestler', [RankingController::class, 'ranking_list_wrestler']);
 Route::get('/ranking-list-tag-team', [RankingController::class, 'ranking_list_tag_team']);
+Route::get('/ranking-list-federation', [RankingController::class, 'ranking_list_federation']);
 
 // Vote Routes
 Route::get('/vote-lists', [VoteController::class, 'index'])->name('vote.lists.index');
@@ -110,6 +112,8 @@ Route::middleware(['auth.custom'])->group(function () {
     Route::post('/voteWrestler', [VoteController::class, 'wrestlerVoteStore'])->name('vote.wrestler.store');
     Route::get('/voteTagTeam/{tagTeam}/{ranking}', [VoteController::class, 'showTagTeamVoteForm'])->name('vote.tagTeam.form');
     Route::post('/voteTagTeam', [VoteController::class, 'tagTeamVoteStore'])->name('vote.tagTeam.store');
+    Route::get('/voteFederation/{federation}/{ranking}', [VoteController::class, 'showFederationVoteForm'])->name('vote.federation.form');
+    Route::post('/voteFederation', [VoteController::class, 'federationVoteStore'])->name('vote.federation.store');
 });
 
 // Wrestler Routes
@@ -123,3 +127,4 @@ Route::get('/tag-team-candidates', [TagTeamController::class, 'candidates'])->na
 // Feds Routes
 Route::get('/federations', [FederationController::class, 'index'])->name('federations.index');
 Route::get('/list-per-fed&{id}', [FederationController::class, 'show'])->name('federations.show');
+Route::get('/federation-candidates', [FederationController::class, 'candidates'])->name('federations.candidates');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,23 +1,24 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\UserController;
-use App\Http\Controllers\VoteController;
-use App\Http\Controllers\RankingController;
-use App\Http\Controllers\Auth\SessionController;
-use App\Http\Controllers\TagTeamController;
-use App\Http\Controllers\WrestlerController;
-use App\Http\Controllers\FederationController;
-use App\Http\Controllers\Auth\RegisteredUserController;
-use App\Http\Controllers\Admin\DashboardController;
-use App\Http\Controllers\Admin\UserManagementController;
-use App\Http\Controllers\Admin\WrestlerManagementController;
-use App\Http\Controllers\Admin\TagTeamManagementController;
 use App\Http\Controllers\Admin\CategoryManagementController;
+use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\FederationManagementController;
 use App\Http\Controllers\Admin\RankingManagementController;
+use App\Http\Controllers\Admin\TagTeamManagementController;
+use App\Http\Controllers\Admin\UserManagementController;
+use App\Http\Controllers\Admin\WrestlerManagementController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
+use App\Http\Controllers\Auth\RegisteredUserController;
+use App\Http\Controllers\Auth\SessionController;
+use App\Http\Controllers\FederationController;
+use App\Http\Controllers\RankingController;
+use App\Http\Controllers\SearchController;
+use App\Http\Controllers\TagTeamController;
+use App\Http\Controllers\UserController;
+use App\Http\Controllers\VoteController;
+use App\Http\Controllers\WrestlerController;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('index');
@@ -26,6 +27,8 @@ Route::get('/', function () {
 Route::get('/about-project', function () {
     return view('about');
 })->name('about');
+
+Route::get('/search', [SearchController::class, 'index'])->name('search.index');
 
 // Auth Routes
 Route::middleware('guest')->group(function(){

--- a/tests/Feature/Controller/AdminCrudControllersTest.php
+++ b/tests/Feature/Controller/AdminCrudControllersTest.php
@@ -197,4 +197,72 @@ class AdminCrudControllersTest extends TestCase
             'status' => 1,
         ]);
     }
+
+    public function test_admin_can_create_only_one_federation_ranking_from_dedicated_action(): void
+    {
+        $admin = $this->admin();
+
+        $first = $this->actingAs($admin)->post(route('admin.ranking.federation.create'));
+        $first->assertRedirect(route('admin.ranking'));
+        $first->assertSessionHas('success', 'Ranking federazioni creato con successo.');
+
+        $this->assertDatabaseHas('rankings', [
+            'type' => RankingType::Federation->value,
+            'name' => 'Ranking Federazioni',
+        ]);
+
+        $second = $this->actingAs($admin)->post(route('admin.ranking.federation.create'));
+        $second->assertRedirect(route('admin.ranking'));
+        $second->assertSessionHas('error', 'Il ranking federazioni esiste già.');
+
+        $this->assertSame(1, Ranking::where('type', RankingType::Federation->value)->count());
+    }
+
+    public function test_edit_federation_ranking_hides_filter_fields_and_update_resets_filters(): void
+    {
+        $admin = $this->admin();
+        $category = Category::factory()->create();
+        $federation = Federation::factory()->create();
+
+        $ranking = Ranking::factory()->create([
+            'type' => RankingType::Federation->value,
+            'category_id' => $category->id,
+            'federation_id' => $federation->id,
+            'country' => 'Italy',
+            'filter_type' => 'multiple',
+        ]);
+
+        $ranking->categories()->sync([$category->id]);
+        $ranking->federations()->sync([$federation->id]);
+        $ranking->rankingCountries()->create(['country' => 'Italy']);
+
+        $edit = $this->actingAs($admin)->get(route('admin.ranking.edit', $ranking->id));
+        $edit->assertOk();
+        $edit->assertDontSee('Categorie (facoltative, selezione multipla):');
+        $edit->assertDontSee('Federazioni (facoltative, selezione multipla):');
+        $edit->assertDontSee('Nazionalità (una o più, separate da virgola):');
+
+        $update = $this->actingAs($admin)->put(route('admin.ranking.update', $ranking->id), [
+            'name' => 'Federation Ranking Updated',
+            'description' => 'Updated',
+            'status' => 1,
+            // injected filter payload should be ignored for federation rankings
+            'category_ids' => [$category->id],
+            'federation_ids' => [$federation->id],
+            'countries_text' => 'Japan',
+        ]);
+
+        $update->assertRedirect(route('admin.ranking'));
+
+        $ranking->refresh();
+        $this->assertSame('Federation Ranking Updated', $ranking->name);
+        $this->assertNull($ranking->category_id);
+        $this->assertNull($ranking->federation_id);
+        $this->assertNull($ranking->country);
+        $this->assertSame('none', $ranking->filter_type);
+
+        $this->assertCount(0, $ranking->categories);
+        $this->assertCount(0, $ranking->federations);
+        $this->assertCount(0, $ranking->rankingCountries);
+    }
 }

--- a/tests/Feature/Controller/RankingControllerTest.php
+++ b/tests/Feature/Controller/RankingControllerTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature\Controller;
 
+use App\Enums\RankingType;
 use App\Models\Category;
 use App\Models\Federation;
 use App\Models\Ranking;
+use App\Models\RankingFederationAverage;
 use App\Models\RankingTagTeamAverage;
 use App\Models\RankingWrestlerAverage;
 use App\Models\TagTeam;
@@ -156,5 +158,65 @@ class RankingControllerTest extends TestCase
         $response->assertOk();
         $response->assertViewIs('votes.tag_team.ranking-list');
         $response->assertSee('Tag Team Legacy');
+    }
+
+     public function test_show_federation_ranking_displays_participants_ordered_by_average(): void
+    {
+        $ranking = Ranking::factory()->create([
+            'type' => RankingType::Federation->value,
+        ]);
+
+        $f1 = Federation::factory()->create();
+        $f2 = Federation::factory()->create();
+
+        RankingFederationAverage::create([
+            'ranking_id' => $ranking->id,
+            'federation_id' => $f1->id,
+            'votes_count' => 5,
+            'votes_sum' => 30,
+            'average_vote' => 6.0,
+        ]);
+
+        RankingFederationAverage::create([
+            'ranking_id' => $ranking->id,
+            'federation_id' => $f2->id,
+            'votes_count' => 5,
+            'votes_sum' => 45,
+            'average_vote' => 9.0,
+        ]);
+
+        $response = $this->get(route('rankings.show', $ranking->id));
+
+        $response->assertOk();
+        $response->assertViewIs('rankings.show');
+        $response->assertViewHas('participants', function ($participants) use ($f2, $f1) {
+            return $participants->count() === 2
+                && $participants->first()->participant->id === $f2->id
+                && $participants->last()->participant->id === $f1->id;
+        });
+    }
+
+    public function test_federation_ranking_list_shows_empty_message_when_no_active_rankings(): void
+    {
+        $response = $this->get('/ranking-list-federation');
+
+        $response->assertOk();
+        $response->assertViewIs('votes.federation.ranking-list');
+        $response->assertSee('Non ci sono federation ranking disponibili.');
+    }
+
+    public function test_federation_ranking_list_shows_active_rankings(): void
+    {
+        Ranking::factory()->create([
+            'name' => 'Federation Annual',
+            'type' => RankingType::Federation->value,
+            'status' => true,
+        ]);
+
+        $response = $this->get('/ranking-list-federation');
+
+        $response->assertOk();
+        $response->assertViewIs('votes.federation.ranking-list');
+        $response->assertSee('Federation Annual');
     }
 }

--- a/tests/Feature/Controller/SearchControllerTest.php
+++ b/tests/Feature/Controller/SearchControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Controller;
+
+use App\Models\Federation;
+use App\Models\Ranking;
+use App\Models\TagTeam;
+use App\Models\Wrestler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SearchControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_search_page_loads_without_query(): void
+    {
+        $response = $this->get(route('search.index'));
+
+        $response->assertOk();
+        $response->assertSeeText('Inserisci un testo nella barra di ricerca');
+    }
+
+    public function test_search_returns_matching_results_for_each_entity(): void
+    {
+        Wrestler::factory()->create(['name' => 'Kenny Omega', 'category_id' => null, 'federation_id' => null]);
+        TagTeam::factory()->create(['name' => 'Omega Lovers', 'category_id' => null, 'federation_id' => null]);
+        Federation::factory()->create(['name' => 'Omega Wrestling']);
+        Ranking::factory()->create(['name' => 'Best Omega Ranking']);
+
+        $response = $this->get(route('search.index', ['query' => 'Omega']));
+
+        $response->assertOk();
+        $response->assertSeeText('Kenny Omega');
+        $response->assertSeeText('Omega Lovers');
+        $response->assertSeeText('Omega Wrestling');
+        $response->assertSeeText('Best Omega Ranking');
+    }
+}

--- a/tests/Feature/Controller/VoteControllerTest.php
+++ b/tests/Feature/Controller/VoteControllerTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\Controller;
 
+use App\Enums\RankingType;
 use App\Models\Category;
 use App\Models\Federation;
 use App\Models\Ranking;
 use App\Models\TagTeam;
 use App\Models\User;
+use App\Models\VoteFederation;
 use App\Models\VoteTagTeam;
 use App\Models\VoteWrestler;
 use App\Models\Wrestler;
@@ -220,5 +222,106 @@ class VoteControllerTest extends TestCase
             'ranking_id' => $ranking->id,
             'vote' => 8,
         ]);
+    }
+
+    public function test_guest_cannot_submit_federation_vote(): void
+    {
+        $federation = Federation::factory()->create();
+        $ranking = Ranking::factory()->create([
+            'type' => RankingType::Federation->value,
+            'status' => true,
+        ]);
+
+        $response = $this->post(route('vote.federation.store'), [
+            'federation_id' => $federation->id,
+            'ranking_id' => $ranking->id,
+            'vote' => 8.5,
+        ]);
+
+        $response->assertRedirect('/');
+        $response->assertSessionHas('error', 'Devi essere loggato per accedere a questa sezione.');
+        $this->assertDatabaseCount('votes_federation', 0);
+    }
+
+    public function test_user_can_submit_federation_vote_once(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $federation = Federation::factory()->create();
+        $ranking = Ranking::factory()->create([
+            'type' => RankingType::Federation->value,
+            'status' => true,
+        ]);
+
+        $response = $this->actingAs($user)->post(route('vote.federation.store'), [
+            'federation_id' => $federation->id,
+            'ranking_id' => $ranking->id,
+            'vote' => 7.5,
+        ]);
+
+        $response->assertRedirect(route('user.profile'));
+        $response->assertSessionHas('success', 'Il tuo voto è stato salvato con successo.');
+
+        $this->assertDatabaseHas('votes_federation', [
+            'user_id' => $user->id,
+            'federation_id' => $federation->id,
+            'ranking_id' => $ranking->id,
+            'vote' => 7.5,
+        ]);
+    }
+
+    public function test_user_can_update_existing_federation_vote(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $federation = Federation::factory()->create();
+        $ranking = Ranking::factory()->create([
+            'type' => RankingType::Federation->value,
+            'status' => true,
+        ]);
+
+        VoteFederation::create([
+            'user_id' => $user->id,
+            'federation_id' => $federation->id,
+            'ranking_id' => $ranking->id,
+            'vote' => 9,
+        ]);
+
+        $response = $this->actingAs($user)->post(route('vote.federation.store'), [
+            'federation_id' => $federation->id,
+            'ranking_id' => $ranking->id,
+            'vote' => 8,
+        ]);
+
+        $response->assertRedirect(route('user.profile'));
+        $this->assertDatabaseCount('votes_federation', 1);
+        $this->assertDatabaseHas('votes_federation', [
+            'user_id' => $user->id,
+            'federation_id' => $federation->id,
+            'ranking_id' => $ranking->id,
+            'vote' => 8,
+        ]);
+    }
+
+    public function test_user_cannot_submit_federation_vote_to_wrestler_ranking(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $federation = Federation::factory()->create();
+        $ranking = Ranking::factory()->create([
+            'type' => RankingType::Wrestler->value,
+            'status' => true,
+        ]);
+
+        $response = $this->actingAs($user)->from('/voteFederation/' . $federation->id . '/' . $ranking->id)
+            ->post(route('vote.federation.store'), [
+                'federation_id' => $federation->id,
+                'ranking_id' => $ranking->id,
+                'vote' => 6,
+            ]);
+
+        $response->assertRedirect('/voteFederation/' . $federation->id . '/' . $ranking->id);
+        $response->assertSessionHas('error', 'Questo ranking non accetta votazioni per federazioni.');
+        $this->assertDatabaseCount('votes_federation', 0);
     }
 }


### PR DESCRIPTION
…nking type, vote persistence, and average rebuild support.

Introduce dedicated admin creation flow (single federation ranking) with simplified edit fields. Wire routes/controllers/views for federation voting, candidate list, and rankings visibility. Expand feature tests to cover federation voting, ranking list/show, and admin constraints.